### PR TITLE
Fix meta.json permission denied issue

### DIFF
--- a/src/aws_object_search/tantivy_wrapper.py
+++ b/src/aws_object_search/tantivy_wrapper.py
@@ -112,6 +112,12 @@ def _fix_tantivy_permissions(index_path: Path) -> None:
         # Set permissions to 644 (rw-r--r--)
         os.chmod(managed_json_path, 0o644)
 
+    # Fix permissions for meta.json file
+    meta_json_path = index_path / "meta.json"
+    if meta_json_path.exists():
+        # Set permissions to 644 (rw-r--r--) for read access by all
+        os.chmod(meta_json_path, 0o644)
+
     # Fix permissions for .tantivy-meta.lock file
     meta_lock_path = index_path / ".tantivy-meta.lock"
     if meta_lock_path.exists():

--- a/tests/test_tantivy_wrapper.py
+++ b/tests/test_tantivy_wrapper.py
@@ -306,3 +306,43 @@ def test_tantivy_meta_lock_permissions(tmp_path):
         assert writable_by_other, (
             f".tantivy-meta.lock writable by others, got: {file_permissions}"
         )
+
+
+def test_meta_json_permissions(tmp_path):
+    """Test that meta.json file has proper read permissions after index creation."""
+    import stat
+
+    # Create an index
+    sample_documents = [
+        {
+            "bucket_name": "test-bucket",
+            "key": "test/file.txt",
+            "size": "1024",
+            "storage_class": "STANDARD",
+        }
+    ]
+
+    regenerate_index(tmp_path, sample_documents)
+
+    # Check that meta.json exists and has proper permissions
+    meta_json_path = tmp_path / "meta.json"
+    assert meta_json_path.exists(), "meta.json should exist after index creation"
+
+    # Get file permissions
+    file_stat = meta_json_path.stat()
+    file_permissions = stat.filemode(file_stat.st_mode)
+
+    # Check that the file is readable by all (at least r--r--r--)
+    readable_by_owner = file_stat.st_mode & stat.S_IRUSR
+    readable_by_group = file_stat.st_mode & stat.S_IRGRP
+    readable_by_other = file_stat.st_mode & stat.S_IROTH
+
+    assert readable_by_owner, (
+        f"meta.json should be readable by owner, got: {file_permissions}"
+    )
+    assert readable_by_group, (
+        f"meta.json should be readable by group, got: {file_permissions}"
+    )
+    assert readable_by_other, (
+        f"meta.json should be readable by others, got: {file_permissions}"
+    )


### PR DESCRIPTION
## Summary

Fixes the "Permission denied" error when trying to read `meta.json` file created by Tantivy search index operations.

## Problem

When Tantivy creates the `meta.json` file, it was created with restrictive permissions (600 - `rw-------`) that prevented other processes or users from reading the index metadata file, causing `IoError { io_error: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }, filepath: "meta.json" }` errors.

## Solution

- Update existing `_fix_tantivy_permissions()` helper function to handle `meta.json` file
- Set `meta.json` permissions to 644 (`rw-r--r--`) for read access by all
- Maintain existing permission fixes for `.managed.json` and `.tantivy-meta.lock` files
- Add focused test `test_meta_json_permissions()` to verify correct permissions

## Testing

- ✅ New test `test_meta_json_permissions()` verifies `meta.json` has proper read permissions
- ✅ All existing tests continue to pass including previous permission fixes
- ✅ Code passes ruff quality checks

## Test Plan

- [x] New permission test passes
- [x] All existing functionality tests pass  
- [x] Code quality checks pass with ruff
- [x] No regressions in previous permission fixes

The fix ensures search operations can read the index metadata file without encountering permission denied errors in multi-user environments.

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)